### PR TITLE
fix error when adding float to int

### DIFF
--- a/gini.py
+++ b/gini.py
@@ -12,7 +12,7 @@ def gini(array):
         # Values cannot be negative:
         array -= np.amin(array)
     # Values cannot be 0:
-    array += 0.0000001
+    array = array + 0.0000001
     # Values must be sorted:
     array = np.sort(array)
     # Index per array element:


### PR DESCRIPTION
numpy throws a `TypeError` in `array += 0.0000001` when `array` is an array of integers. This simply recreates `array` with the new values to account for this.

PS cheers for this implementation!